### PR TITLE
feat: pr target

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request_target:
+    types: [opened, edited]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request_target:
-    branches: [main]
+  pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request_target:
-    types: [opened, edited]
+    branches: [main]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: PR
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
So outside contributors can run using our repo's ETH_RPC_URL secret.

Outside PRs will be manually reviewed first.