### PR TITLE
feat: add support for historical block proofs up to 24h

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7734aecfc58a597dde036e4c5cace2ae43e2f8bf3d406b022a1ef34da178dd49"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "num_enum 0.7.3",
  "serde",
@@ -97,7 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2179ba839ac532f50279f5da2a6c5047f791f03f6f808b4dfab11327b97902f"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
@@ -121,7 +121,7 @@ checksum = "aec6f67bdc62aa277e0ec13c1b1fb396c8a62b65c8e9bd8c1d3583cc6d1a8dd3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "alloy-serde",
  "serde",
@@ -138,7 +138,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-provider",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
@@ -156,7 +156,7 @@ checksum = "9d020a85ae8cf79b9c897a86d617357817bbc9a7d159dd7e6fedf1bc90f64d35"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "alloy-sol-types",
 ]
@@ -168,7 +168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884a5d4560f7e5e34ec3c5e54a60223c56352677dd049b495fbb59384cf72a90"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
@@ -184,7 +184,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "crc",
  "serde",
@@ -197,7 +197,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbe3e16484669964c26ac48390245d84c410b1a5f968976076c17184725ef235"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "serde",
 ]
@@ -208,7 +208,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804cefe429015b4244966c006d25bda5545fa9db5990e9c9079faf255052f50a"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
@@ -225,7 +225,7 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
@@ -245,7 +245,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-hardforks",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.0.1",
@@ -262,7 +262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dfec8348d97bd624901c6a4b22bb4c24df8a3128fc3d5e42d24f7b79dfa8588"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-serde",
  "alloy-trie",
  "serde",
@@ -276,7 +276,7 @@ checksum = "c7d3b2243e2adfaea41da41982f91ecab8083fa51b240d0427955d709f65b1b4"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "auto_impl",
  "dyn-clone",
 ]
@@ -287,7 +287,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5189fa9a8797e92396bc4b4454c5f2073a4945f7c2b366af9af60f9536558f7a"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -299,7 +299,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3994ab6ff6bdeb5aebe65381a8f6a47534789817570111555e8ac413e242ce06"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-sol-types",
  "serde",
  "serde_json",
@@ -318,7 +318,7 @@ dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -341,9 +341,52 @@ checksum = "498f2ee2eef38a6db0fc810c7bf7daebdf5f2fa8d04adb8bd53e54e91ddbdea3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-serde",
  "serde",
+]
+
+[[package]]
+name = "alloy-node-bindings"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60dd250ffe9514728daf5e84cac7193e221b85feffe3bea7d45f2b9fcbe6b885"
+dependencies = [
+ "alloy-genesis",
+ "alloy-hardforks",
+ "alloy-network",
+ "alloy-primitives 1.0.0",
+ "alloy-signer",
+ "alloy-signer-local",
+ "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.8.5",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 0.99.20",
+ "hex-literal",
+ "itoa",
+ "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-asm",
+ "proptest",
+ "rand 0.8.5",
+ "ruint",
+ "serde",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -386,7 +429,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
  "alloy-signer",
@@ -442,7 +485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6a6985b48a536b47aa0aece56e6a0f49240ce5d33a7f0c94f1b312eda79aa1"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-transport",
  "alloy-transport-http",
  "async-stream",
@@ -466,7 +509,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf27873220877cb15125eb6eec2f86c6e9b41473aca85844bd3d9d755bfc0a0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -491,7 +534,7 @@ checksum = "4235d79af20fe5583ca26096258fe9307571a345745c433cfd8c91b41aa2611e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 2.0.1",
@@ -509,7 +552,7 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
@@ -525,7 +568,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "serde",
  "serde_json",
 ]
@@ -536,11 +579,11 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c580da7f00f3999e44e327223044d6732358627f93043e22d92c583f6583556"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "async-trait",
  "auto_impl",
  "either",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.12",
 ]
@@ -553,7 +596,7 @@ checksum = "a00f0f07862bd8f6bc66c953660693c5903062c2c9d308485b2a6eee411089e7"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-signer",
  "async-trait",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -629,7 +672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c02635bce18205ff8149fb752c753b0a91ea3f3c8ee04c58846448be4811a640"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-sol-macro",
  "const-hex",
  "serde",
@@ -642,7 +685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1f1a55f9ff9a48aa0b4a8c616803754620010fbb266edae2f4548f4304373b"
 dependencies = [
  "alloy-json-rpc",
- "base64",
+ "base64 0.22.1",
  "derive_more 2.0.1",
  "futures",
  "futures-utils-wasm",
@@ -678,7 +721,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.0.1",
@@ -1235,9 +1278,21 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1408,6 +1463,12 @@ dependencies = [
  "threadpool",
  "zeroize",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
@@ -1673,6 +1734,12 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
@@ -1705,6 +1772,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1775,6 +1851,18 @@ name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -1935,6 +2023,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +2094,19 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -2023,7 +2140,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -2123,17 +2240,29 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.9",
  "digest 0.10.7",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "rfc6979 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serdect",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2141,12 +2270,12 @@ name = "ecdsa"
 version = "0.16.9"
 source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
- "der",
+ "der 0.7.9",
  "digest 0.10.7",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "rfc6979 0.4.0 (git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0)",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2178,21 +2307,41 @@ checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
 
 [[package]]
 name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.7",
+ "ff 0.12.1",
+ "generic-array 0.14.7",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.1",
  "generic-array 0.14.7",
  "group 0.13.0",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
  "serdect",
  "subtle",
  "zeroize",
@@ -2203,6 +2352,34 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "enr"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fa0a0be8915790626d5759eb51fe47435a8eac92c2f212bd2da9aa7f30ea56"
+dependencies = [
+ "base64 0.13.1",
+ "bs58",
+ "bytes",
+ "hex",
+ "k256 0.11.6",
+ "log",
+ "rand 0.8.5",
+ "rlp",
+ "serde",
+ "sha3",
+ "zeroize",
+]
 
 [[package]]
 name = "enum-map"
@@ -2273,6 +2450,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum-consensus"
+version = "0.1.1"
+source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=ba43147eb71b07e21e156e2904549405f87bc9a6#ba43147eb71b07e21e156e2904549405f87bc9a6"
+dependencies = [
+ "blst",
+ "bs58",
+ "c-kzg",
+ "enr",
+ "hex",
+ "integer-sqrt",
+ "multiaddr",
+ "multihash",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2 0.10.8",
+ "ssz_rs",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "events"
 version = "0.1.0"
 dependencies = [
@@ -2295,7 +2496,7 @@ dependencies = [
 name = "events-client"
 version = "0.0.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rpc-types",
  "alloy-sol-types",
  "sp1-cc-client-executor",
@@ -2318,7 +2519,7 @@ name = "example-deploy"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-sol-macro",
@@ -2761,6 +2962,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,6 +3359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,17 +3457,29 @@ dependencies = [
 
 [[package]]
 name = "k256"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+dependencies = [
+ "cfg-if",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "once_cell",
  "serdect",
  "sha2 0.10.8",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -3261,11 +3489,11 @@ source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.9 (git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0)",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "hex",
  "once_cell",
  "sha2 0.10.8",
- "signature",
+ "signature 2.2.0",
  "sp1-lib",
 ]
 
@@ -3350,7 +3578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64",
+ "base64 0.22.1",
  "digest 0.9.0",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
@@ -3388,6 +3616,12 @@ checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3549,10 +3783,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c580bfdd8803cce319b047d239559a22f809094aaea4ac13902a1fdcfcd4261"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint",
+ "url",
+]
+
+[[package]]
+name = "multihash"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
+dependencies = [
+ "core2",
+ "digest 0.10.7",
+ "multihash-derive",
+ "sha2 0.10.8",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
+]
+
+[[package]]
 name = "multiplexer"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-sol-macro",
@@ -3572,7 +3851,7 @@ dependencies = [
 name = "multiplexer-client"
 version = "0.0.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-sol-macro",
  "alloy-sol-types",
  "bincode",
@@ -3847,7 +4126,7 @@ checksum = "1a09198717ebb22b201442c12a306a62de4a5d9535993b975c6bc0e5a919e2b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 2.0.1",
@@ -3937,7 +4216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "primeorder",
  "sha2 0.10.8",
 ]
@@ -4404,12 +4683,22 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.9",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -4455,7 +4744,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -4486,6 +4775,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit 0.22.24",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -4825,10 +5138,12 @@ version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -4852,6 +5167,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -4892,7 +5208,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-trie",
  "auto_impl",
  "derive_more 2.0.1",
@@ -4910,7 +5226,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-trie",
  "bytes",
  "modular-bitfield",
@@ -4925,7 +5241,7 @@ name = "reth-codecs-derive"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -4937,7 +5253,7 @@ version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -4962,7 +5278,7 @@ version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "bytes",
  "reth-primitives-traits",
  "serde",
@@ -4987,7 +5303,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac72
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -5003,7 +5319,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac72
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "auto_impl",
  "once_cell",
  "rustc-hash 2.1.1",
@@ -5018,7 +5334,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "derive_more 2.0.1",
@@ -5040,7 +5356,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "auto_impl",
  "derive_more 2.0.1",
  "futures-util",
@@ -5063,7 +5379,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -5079,7 +5395,7 @@ version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
  "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
@@ -5094,7 +5410,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "derive_more 2.0.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -5128,7 +5444,7 @@ name = "reth-network-peers"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "secp256k1 0.30.0",
  "serde_with",
@@ -5157,7 +5473,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "alloy-trie",
  "auto_impl",
@@ -5181,7 +5497,7 @@ name = "reth-prune-types"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "derive_more 2.0.1",
  "serde",
  "thiserror 2.0.12",
@@ -5192,7 +5508,7 @@ name = "reth-stages-types"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "bytes",
  "reth-trie-common",
  "serde",
@@ -5203,7 +5519,7 @@ name = "reth-static-file-types"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "derive_more 2.0.1",
  "serde",
  "strum 0.27.1",
@@ -5216,7 +5532,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac72
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rpc-types-engine",
  "auto_impl",
  "reth-chainspec",
@@ -5237,7 +5553,7 @@ version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "derive_more 2.0.1",
  "reth-primitives-traits",
@@ -5269,7 +5585,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac72
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "alloy-trie",
  "auto_impl",
@@ -5290,7 +5606,7 @@ version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -5311,7 +5627,7 @@ name = "reth-trie-sparse"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "auto_impl",
  "metrics",
@@ -5497,7 +5813,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc2283ff87358ec7501956c5dd8724a6c2be959c619c4861395ae5e0054575f"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "enumn",
  "serde",
 ]
@@ -5512,6 +5828,17 @@ dependencies = [
  "revm-bytecode",
  "revm-primitives",
  "serde",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -5594,7 +5921,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-evm",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rpc-types",
  "itertools 0.13.0",
  "reth-chainspec",
@@ -5622,7 +5949,7 @@ name = "rsp-mpt"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.3.10#4081e40833aebece5958518724a327ede100f6cd"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "reth-trie",
  "rlp",
@@ -5650,7 +5977,7 @@ name = "rsp-rpc-db"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.3.10#4081e40833aebece5958518724a327ede100f6cd"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-provider",
  "alloy-rpc-types",
  "reth-storage-errors",
@@ -5667,7 +5994,7 @@ name = "rsp-witness-db"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.3.10#4081e40833aebece5958518724a327ede100f6cd"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "reth-storage-errors",
  "revm-database-interface",
  "revm-primitives",
@@ -5902,14 +6229,28 @@ checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array 0.14.7",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.9",
  "generic-array 0.14.7",
- "pkcs8",
+ "pkcs8 0.10.2",
  "serdect",
  "subtle",
  "zeroize",
@@ -6097,7 +6438,7 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -6122,12 +6463,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap 1.9.3",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "serde",
 ]
 
@@ -6224,6 +6577,16 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -6302,7 +6665,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rpc-types",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -6321,6 +6684,7 @@ dependencies = [
  "rsp-witness-db",
  "serde",
  "serde_with",
+ "sha2 0.10.8",
  "thiserror 2.0.12",
 ]
 
@@ -6331,20 +6695,24 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-sol-macro",
  "alloy-sol-types",
  "alloy-transport",
+ "async-trait",
  "bincode",
  "dotenv",
+ "ethereum-consensus",
  "eyre",
+ "reqwest",
  "revm",
  "revm-primitives",
  "rsp-mpt",
  "rsp-primitives",
  "rsp-rpc-db",
+ "serde",
  "sp1-cc-client-executor",
  "thiserror 2.0.12",
  "tokio",
@@ -6402,7 +6770,7 @@ dependencies = [
  "cbindgen",
  "cc",
  "cfg-if",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "generic-array 1.1.0",
  "glob",
  "hashbrown 0.14.5",
@@ -6473,7 +6841,7 @@ checksum = "a198a00a1700ea0073a7481138abf256e3f38a15892c42721cdbec5d64d0f4e7"
 dependencies = [
  "cfg-if",
  "dashu",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "generic-array 1.1.0",
  "itertools 0.13.0",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6504,7 +6872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3ef88f90458b6116da164e9c4c4596c49c8cca1944bfe02850b48b232a06b90"
 dependencies = [
  "bincode",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "serde",
  "sp1-primitives",
 ]
@@ -6716,7 +7084,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9dc0553bed3674fe271a65dd9cdd3569670c619fdc3aaac7588cc6fce39e622"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -6832,12 +7200,44 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.9",
+]
+
+[[package]]
+name = "ssz_rs"
+version = "0.9.0"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=84ef2b71aa004f6767420badb42c902ad56b8b72#84ef2b71aa004f6767420badb42c902ad56b8b72"
+dependencies = [
+ "alloy-primitives 0.7.7",
+ "bitvec",
+ "serde",
+ "sha2 0.9.9",
+ "ssz_rs_derive",
+]
+
+[[package]]
+name = "ssz_rs_derive"
+version = "0.9.0"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=84ef2b71aa004f6767420badb42c902ad56b8b72#84ef2b71aa004f6767420badb42c902ad56b8b72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6965,6 +7365,18 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
@@ -6987,6 +7399,27 @@ dependencies = [
  "once_cell",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -7260,7 +7693,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -7563,7 +7996,9 @@ name = "uniswap"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-primitives",
+ "alloy-contract",
+ "alloy-node-bindings",
+ "alloy-primitives 1.0.0",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-sol-macro",
@@ -7586,13 +8021,19 @@ dependencies = [
 name = "uniswap-client"
 version = "0.0.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-sol-macro",
  "alloy-sol-types",
  "bincode",
  "sp1-cc-client-executor",
  "sp1-zkvm",
 ]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 
 [[package]]
 name = "untrusted"
@@ -7654,7 +8095,7 @@ dependencies = [
 name = "verify-quorum"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-sol-macro",
@@ -7678,7 +8119,7 @@ dependencies = [
 name = "verify-quorum-client"
 version = "0.0.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-sol-macro",
  "alloy-sol-types",
  "bincode",
@@ -8233,6 +8674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8253,7 +8703,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "synstructure",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -8314,7 +8764,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "synstructure",
+ "synstructure 0.13.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1.21", default-features = false, features = [
 ] }
 serde_json = "1.0.94"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+reqwest = "0.12.15"
 url = "2.3"
 hex-literal = "0.4.1"
 bincode = "1.3.3"
@@ -96,7 +97,9 @@ revm-primitives = { version = "18.0.0", features = [
 # alloy
 alloy-primitives = "1.0"
 alloy-consensus = { version = "0.14.0", default-features = false }
+alloy-contract = { version = "0.14.0", default-features = false }
 alloy-eips = { version = "0.14.0", default-features = false }
+alloy-node-bindings = { version = "0.14.0", default-features = false }
 alloy-provider = { version = "0.14.0", default-features = false, features = [
     "reqwest",
 ] }
@@ -114,6 +117,11 @@ alloy-sol-macro = { version = "1.0" }
 alloy = { version = "0.14.0" }
 
 alloy-evm = { version = "0.4.0", default-features = false }
+
+sha2 = "0.10.8"
+beacon-api-client = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "ba43147eb71b07e21e156e2904549405f87bc9a6" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "ba43147eb71b07e21e156e2904549405f87bc9a6" }
+async-trait = "0.1.88"
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"

--- a/crates/client-executor/Cargo.toml
+++ b/crates/client-executor/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 eyre.workspace = true
 serde.workspace = true
+sha2.workspace = true
 serde_with = "3.12.0"
 thiserror.workspace = true
 

--- a/crates/client-executor/src/anchor.rs
+++ b/crates/client-executor/src/anchor.rs
@@ -1,0 +1,105 @@
+use alloy_consensus::Header;
+use alloy_primitives::{B256, U256};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use sha2::{Digest, Sha256};
+
+use crate::AnchorType;
+
+/// The generalized Merkle tree index of the `block_hash` field in the `BeaconBlock`.
+pub const BLOCK_HASH_LEAF_INDEX: usize = 6444;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Anchor {
+    Header(HeaderAnchor),
+    Beacon(BeaconAnchor),
+}
+
+impl Anchor {
+    pub fn header(&self) -> &Header {
+        match self {
+            Anchor::Header(header_anchor) => &header_anchor.header,
+            Anchor::Beacon(beacon_anchor) => &beacon_anchor.inner.header,
+        }
+    }
+
+    pub fn id(&self) -> U256 {
+        match self {
+            Anchor::Header(header_anchor) => U256::from(header_anchor.header.number),
+            Anchor::Beacon(beacon_anchor) => U256::from(beacon_anchor.timestamp),
+        }
+    }
+
+    pub fn hash(&self) -> B256 {
+        match self {
+            Anchor::Header(header_anchor) => header_anchor.header.hash_slow(),
+            Anchor::Beacon(beacon_anchor) => {
+                let block_hash = beacon_anchor.inner.header.hash_slow();
+
+                rebuild_merkle_root(block_hash, BLOCK_HASH_LEAF_INDEX, &beacon_anchor.proof)
+            }
+        }
+    }
+
+    pub fn ty(&self) -> AnchorType {
+        match self {
+            Anchor::Header(_) => AnchorType::BlockHash,
+            Anchor::Beacon(_) => AnchorType::BeaconRoot,
+        }
+    }
+}
+
+impl From<Header> for Anchor {
+    fn from(header: Header) -> Self {
+        Self::Header(HeaderAnchor { header })
+    }
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HeaderAnchor {
+    #[serde_as(as = "alloy_consensus::serde_bincode_compat::Header")]
+    header: Header,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BeaconAnchor {
+    inner: HeaderAnchor,
+    proof: Vec<B256>,
+    timestamp: u64,
+}
+
+impl BeaconAnchor {
+    pub fn new(header: Header, proof: Vec<B256>, timestamp: u64) -> Self {
+        Self { inner: HeaderAnchor { header }, proof, timestamp }
+    }
+}
+
+pub fn rebuild_merkle_root(leaf: B256, generalized_index: usize, branch: &[B256]) -> B256 {
+    let mut current_hash = leaf;
+    let depth = generalized_index.ilog2();
+    let mut index = generalized_index - (1 << depth);
+    let mut hasher = Sha256::new();
+
+    for sibling in branch {
+        // Determine if the current node is a left or right child
+        let is_left = index % 2 == 0;
+
+        // Combine the current hash with the sibling hash
+        if is_left {
+            // If current node is left child, hash(current + sibling)
+            hasher.update(current_hash);
+            hasher.update(sibling);
+        } else {
+            // If current node is right child, hash(sibling + current)
+            hasher.update(sibling);
+            hasher.update(current_hash);
+        }
+        current_hash.copy_from_slice(&hasher.finalize_reset());
+
+        // Move up to the parent level
+        index /= 2;
+    }
+
+    current_hash
+}

--- a/crates/host-executor/Cargo.toml
+++ b/crates/host-executor/Cargo.toml
@@ -9,7 +9,10 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+async-trait.workspace = true
 eyre.workspace = true
+reqwest.workspace = true
+serde.workspace = true
 url.workspace = true
 tokio.workspace = true
 tracing.workspace = true
@@ -38,8 +41,10 @@ alloy-sol-types.workspace = true
 alloy-rpc-types.workspace = true
 alloy-evm.workspace = true
 
+ethereum-consensus.workspace = true
+
 [dev-dependencies]
 alloy-primitives.workspace = true
+dotenv.workspace = true
 tracing-subscriber = "0.3.18"
 bincode = "1.3.3"
-dotenv.workspace = true

--- a/crates/host-executor/src/anchor_builder.rs
+++ b/crates/host-executor/src/anchor_builder.rs
@@ -11,11 +11,13 @@ use url::Url;
 
 use crate::{beacon_client::BeaconClient, HostError};
 
+/// Abstracts [`Anchor`] creation.
 #[async_trait]
 pub trait AnchorBuilder {
     async fn build<B: Into<BlockId> + Send>(&self, block_id: B) -> Result<Anchor, HostError>;
 }
 
+/// A builder for [`HeaderAnchor`].
 #[derive(Debug)]
 pub struct HeaderAnchorBuilder<P> {
     provider: P,
@@ -56,6 +58,7 @@ impl<P: Provider<AnyNetwork>> AnchorBuilder for HeaderAnchorBuilder<P> {
     }
 }
 
+/// A builder for [`BeaconAnchor`].
 pub struct BeaconAnchorBuilder<P> {
     header_anchor_builder: HeaderAnchorBuilder<P>,
     client: BeaconClient,

--- a/crates/host-executor/src/anchor_builder.rs
+++ b/crates/host-executor/src/anchor_builder.rs
@@ -1,0 +1,117 @@
+use std::fmt::Debug;
+
+use alloy_consensus::{Header, Sealed};
+use alloy_eips::BlockId;
+use alloy_primitives::B256;
+use alloy_provider::{network::AnyNetwork, Provider};
+use async_trait::async_trait;
+use ethereum_consensus::{ssz::prelude::Prove, types::SignedBeaconBlock};
+use sp1_cc_client_executor::{rebuild_merkle_root, Anchor, BeaconAnchor, BLOCK_HASH_LEAF_INDEX};
+use url::Url;
+
+use crate::{beacon_client::BeaconClient, HostError};
+
+#[async_trait]
+pub trait AnchorBuilder {
+    async fn build<B: Into<BlockId> + Send>(&self, block_id: B) -> Result<Anchor, HostError>;
+}
+
+#[derive(Debug)]
+pub struct HeaderAnchorBuilder<P> {
+    provider: P,
+}
+
+impl<P> HeaderAnchorBuilder<P> {
+    pub fn new(provider: P) -> Self {
+        Self { provider }
+    }
+}
+
+impl<P: Provider<AnyNetwork>> HeaderAnchorBuilder<P> {
+    pub async fn get_header<B: Into<BlockId>>(&self, block_id: B) -> Result<Header, HostError> {
+        let block_id = block_id.into();
+        let block = self
+            .provider
+            .get_block(block_id)
+            .await?
+            .ok_or_else(|| HostError::BlockNotFoundError(block_id))?;
+
+        let header = block
+            .header
+            .inner
+            .clone()
+            .try_into_header()
+            .map_err(|_| HostError::HeaderConversionError(block.inner.header.number))?;
+
+        Ok(header)
+    }
+}
+
+#[async_trait]
+impl<P: Provider<AnyNetwork>> AnchorBuilder for HeaderAnchorBuilder<P> {
+    async fn build<B: Into<BlockId> + Send>(&self, block_id: B) -> Result<Anchor, HostError> {
+        let header = self.get_header(block_id).await?;
+
+        Ok(header.into())
+    }
+}
+
+pub struct BeaconAnchorBuilder<P> {
+    header_anchor_builder: HeaderAnchorBuilder<P>,
+    client: BeaconClient,
+}
+
+impl<P> BeaconAnchorBuilder<P> {
+    pub fn new(header_anchor_builder: HeaderAnchorBuilder<P>, cl_rpc_url: Url) -> Self {
+        Self { header_anchor_builder, client: BeaconClient::new(cl_rpc_url) }
+    }
+}
+
+#[async_trait]
+impl<P: Provider<AnyNetwork>> AnchorBuilder for BeaconAnchorBuilder<P> {
+    async fn build<B: Into<BlockId> + Send>(&self, block_id: B) -> Result<Anchor, HostError> {
+        let header = self.header_anchor_builder.get_header(block_id).await?;
+        let child_header = self.header_anchor_builder.get_header(header.number + 1).await?;
+        let header = Sealed::new(header);
+        assert_eq!(child_header.parent_hash, header.seal());
+
+        let beacon_root = child_header
+            .parent_beacon_block_root
+            .ok_or_else(|| HostError::ParentBeaconBlockRootMissing)?;
+        let signed_beacon_block = self.client.get_block(beacon_root.to_string()).await?;
+
+        let (proof, _) = match signed_beacon_block {
+            SignedBeaconBlock::Deneb(signed_beacon_block) => signed_beacon_block
+                .message
+                .prove(&["body".into(), "execution_payload".into(), "block_hash".into()])?,
+            _ => todo!(),
+        };
+
+        assert!(proof.index == BLOCK_HASH_LEAF_INDEX, "the field leaf index is incorrect");
+
+        let proof = proof.branch.iter().map(|n| n.0.into()).collect::<Vec<_>>();
+
+        assert!(
+            verify_merkle_root(header.seal(), &proof, beacon_root),
+            "the proof verification fail"
+        );
+
+        println!("IN HOST: {beacon_root:?}");
+
+        let anchor = BeaconAnchor::new(header.unseal(), proof, child_header.timestamp);
+
+        Ok(Anchor::Beacon(anchor))
+    }
+}
+
+impl<P: Debug> Debug for BeaconAnchorBuilder<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BeaconAnchorBuilder")
+            .field("header_anchor_builder", &self.header_anchor_builder)
+            .finish()
+    }
+}
+
+fn verify_merkle_root(block_hash: B256, proof: &[B256], beacon_root: B256) -> bool {
+    rebuild_merkle_root(block_hash, BLOCK_HASH_LEAF_INDEX, proof) == beacon_root
+}

--- a/crates/host-executor/src/beacon_client.rs
+++ b/crates/host-executor/src/beacon_client.rs
@@ -1,0 +1,39 @@
+use ethereum_consensus::types::mainnet::SignedBeaconBlock;
+use reqwest::Client as ReqwestClient;
+use serde::Deserialize;
+use url::Url;
+
+use crate::HostError;
+
+/// A client used for connecting and querying a beacon node.
+#[derive(Debug, Clone)]
+pub struct BeaconClient {
+    rpc_url: Url,
+    client: ReqwestClient,
+}
+
+/// The data format returned by official Eth Beacon Node APIs.
+#[derive(Debug, Deserialize)]
+struct BeaconData<T> {
+    #[allow(unused)]
+    pub execution_optimistic: bool,
+    #[allow(unused)]
+    pub finalized: bool,
+    pub data: T,
+}
+
+impl BeaconClient {
+    pub fn new(rpc_url: Url) -> Self {
+        Self { rpc_url, client: ReqwestClient::new() }
+    }
+
+    /// Gets the block header at the given `beacon_id`.
+    pub async fn get_block(&self, beacon_id: String) -> Result<SignedBeaconBlock, HostError> {
+        let endpoint = format!("{}eth/v2/beacon/blocks/{}", self.rpc_url, beacon_id);
+
+        let response = self.client.get(&endpoint).send().await?;
+        let parsed = response.error_for_status()?.json::<BeaconData<SignedBeaconBlock>>().await?;
+
+        Ok(parsed.data)
+    }
+}

--- a/crates/host-executor/src/errors.rs
+++ b/crates/host-executor/src/errors.rs
@@ -1,4 +1,4 @@
-use alloy_eips::eip2718::Eip2718Error;
+use alloy_eips::{eip2718::Eip2718Error, BlockId};
 use alloy_transport::TransportError;
 use rsp_mpt::FromProofError;
 use thiserror::Error;
@@ -7,10 +7,18 @@ use thiserror::Error;
 pub enum HostError {
     #[error("Transport error: {0}")]
     TransportError(#[from] TransportError),
+    #[error("Reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
     #[error("Decoding error: {0}")]
     DecodingError(#[from] Eip2718Error),
     #[error("Trie from proof conversion error: {0}")]
     TrieFromProofError(#[from] FromProofError),
+    #[error("Merkleization error: {0}")]
+    MerkleizationError(#[from] ethereum_consensus::ssz::prelude::MerkleizationError),
     #[error("Failed to convert the header for block {0}")]
     HeaderConversionError(u64),
+    #[error("The block {0} don't exists")]
+    BlockNotFoundError(BlockId),
+    #[error("The parent beacon block root is missing in the header")]
+    ParentBeaconBlockRootMissing,
 }

--- a/crates/host-executor/src/sketch.rs
+++ b/crates/host-executor/src/sketch.rs
@@ -15,6 +15,7 @@ use sp1_cc_client_executor::{io::EvmSketchInput, new_evm, Anchor, ContractInput}
 
 use crate::{EvmSketchBuilder, HostError};
 
+/// ['EvmSketch'] is used to prefetch all the data required to execute a block and query logs in the zkVM.
 #[derive(Debug)]
 pub struct EvmSketch<P> {
     /// The genesis block specification.

--- a/crates/host-executor/src/sketch.rs
+++ b/crates/host-executor/src/sketch.rs
@@ -1,0 +1,152 @@
+use std::collections::BTreeSet;
+
+use alloy_consensus::ReceiptEnvelope;
+use alloy_eips::{eip2718::Eip2718Error, Decodable2718, Encodable2718};
+use alloy_evm::Evm;
+use alloy_primitives::{Bytes, B256, U256};
+use alloy_provider::{network::AnyNetwork, Provider};
+use alloy_rpc_types::{AnyReceiptEnvelope, Filter, Log as RpcLog};
+use eyre::eyre;
+use revm::{context::result::ExecutionResult, database::CacheDB};
+use rsp_mpt::EthereumState;
+use rsp_primitives::{account_proof::eip1186_proof_to_account_proof, genesis::Genesis};
+use rsp_rpc_db::RpcDb;
+use sp1_cc_client_executor::{io::EvmSketchInput, new_evm, Anchor, ContractInput};
+
+use crate::{EvmSketchBuilder, HostError};
+
+#[derive(Debug)]
+pub struct EvmSketch<P> {
+    /// The genesis block specification.
+    pub genesis: Genesis,
+    /// The anchor to execute our view functions on.
+    pub anchor: Anchor,
+    /// The [`RpcDb`] used to back the EVM.
+    pub rpc_db: RpcDb<P, AnyNetwork>,
+    /// The receipts used to retrieve event logs.
+    pub receipts: Option<Vec<ReceiptEnvelope>>,
+    /// The provider used to fetch data.
+    pub provider: P,
+}
+
+impl EvmSketch<()> {
+    pub fn builder() -> EvmSketchBuilder<(), ()> {
+        EvmSketchBuilder::default()
+    }
+}
+
+impl<P> EvmSketch<P>
+where
+    P: Provider<AnyNetwork> + Clone,
+{
+    /// Executes the smart contract call with the given [`ContractInput`].
+    pub async fn call(&self, input: ContractInput) -> eyre::Result<Bytes> {
+        let cache_db = CacheDB::new(&self.rpc_db);
+        let mut evm = new_evm(cache_db, self.anchor.header(), U256::ZERO, &self.genesis);
+
+        let output = evm.transact(&input)?;
+
+        let output_bytes = match output.result {
+            ExecutionResult::Success { output, .. } => Ok(output.data().clone()),
+            ExecutionResult::Revert { output, .. } => Ok(output),
+            ExecutionResult::Halt { reason, .. } => Err(eyre!("Execution halted: {reason:?}")),
+        }?;
+
+        Ok(output_bytes.clone())
+    }
+
+    /// Prefetch the logs matching the provided `filter`, allowing them to be retrieved in the
+    /// client using [`get_logs`].
+    ///
+    /// [`get_logs`]: sp1_cc_client_executor::ClientExecutor::get_logs
+    pub async fn get_logs(&mut self, filter: &Filter) -> Result<Vec<RpcLog>, HostError> {
+        let logs = self.provider.get_logs(filter).await?;
+
+        if !logs.is_empty() && self.receipts.is_none() {
+            let receipts = self
+                .provider
+                .get_block_receipts(self.anchor.header().number.into())
+                .await?
+                .unwrap_or_default()
+                .into_iter()
+                .map(|r| convert_receipt_envelope(r.inner.inner))
+                .collect::<Result<_, _>>()?;
+
+            self.receipts = Some(receipts);
+        }
+
+        Ok(logs)
+    }
+
+    /// Returns the cumulative [`EvmSketchInput`] after executing some smart contracts.
+    pub async fn finalize(self) -> Result<EvmSketchInput, HostError> {
+        let block_number = self.anchor.header().number;
+
+        // For every account touched, fetch the storage proofs for all the slots touched.
+        let state_requests = self.rpc_db.get_state_requests();
+        tracing::info!("fetching storage proofs");
+        let mut storage_proofs = Vec::new();
+
+        for (address, used_keys) in state_requests.iter() {
+            let keys = used_keys
+                .iter()
+                .map(|key| B256::from(*key))
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+
+            let storage_proof =
+                self.provider.get_proof(*address, keys).block_id(block_number.into()).await?;
+            storage_proofs.push(eip1186_proof_to_account_proof(storage_proof));
+        }
+
+        let storage_proofs_by_address =
+            storage_proofs.iter().map(|item| (item.address, item.clone())).collect();
+        let state = EthereumState::from_proofs(
+            self.anchor.header().state_root,
+            &storage_proofs_by_address,
+        )?;
+
+        // Fetch the parent headers needed to constrain the BLOCKHASH opcode.
+        let oldest_ancestor = *self.rpc_db.oldest_ancestor.read().unwrap();
+        let mut ancestor_headers = vec![];
+        tracing::info!("fetching {} ancestor headers", block_number - oldest_ancestor);
+        for height in (oldest_ancestor..=(block_number - 1)).rev() {
+            let block = self.provider.get_block_by_number(height.into()).full().await?.unwrap();
+            ancestor_headers.push(
+                block
+                    .inner
+                    .header
+                    .inner
+                    .clone()
+                    .try_into_header()
+                    .map_err(|h| HostError::HeaderConversionError(h.number))?,
+            );
+        }
+
+        Ok(EvmSketchInput {
+            anchor: self.anchor,
+            genesis: self.genesis,
+            ancestor_headers,
+            state,
+            state_requests,
+            bytecodes: self.rpc_db.get_bytecodes(),
+            receipts: self.receipts,
+        })
+    }
+}
+
+fn convert_receipt_envelope(
+    any_receipt_envelope: AnyReceiptEnvelope<RpcLog>,
+) -> Result<ReceiptEnvelope, Eip2718Error> {
+    let any_receipt_envelope = AnyReceiptEnvelope {
+        inner: any_receipt_envelope.inner.map_logs(|l| l.inner),
+        r#type: any_receipt_envelope.r#type,
+    };
+
+    let mut buf = vec![];
+
+    any_receipt_envelope.encode_2718(&mut buf);
+
+    ReceiptEnvelope::decode_2718(&mut buf.as_slice())
+}

--- a/crates/host-executor/src/sketch_builder.rs
+++ b/crates/host-executor/src/sketch_builder.rs
@@ -1,0 +1,92 @@
+use alloy_eips::BlockId;
+use alloy_provider::{network::AnyNetwork, Provider, RootProvider};
+use rsp_primitives::genesis::Genesis;
+use rsp_rpc_db::RpcDb;
+use url::Url;
+
+use crate::{
+    anchor_builder::{AnchorBuilder, BeaconAnchorBuilder, HeaderAnchorBuilder},
+    EvmSketch, HostError,
+};
+
+#[derive(Debug)]
+pub struct EvmSketchBuilder<P, A> {
+    block: BlockId,
+    genesis: Genesis,
+    provider: P,
+    anchor_prefetcher: A,
+}
+
+impl<P, A> EvmSketchBuilder<P, A> {
+    pub fn at_block<B: Into<BlockId>>(mut self, block: B) -> Self {
+        self.block = block.into();
+        self
+    }
+
+    pub fn with_genesis(mut self, genesis: Genesis) -> Self {
+        self.genesis = genesis;
+        self
+    }
+}
+
+impl EvmSketchBuilder<(), ()> {
+    pub fn el_rpc_url(
+        self,
+        rpc_url: Url,
+    ) -> EvmSketchBuilder<RootProvider<AnyNetwork>, HeaderAnchorBuilder<RootProvider<AnyNetwork>>>
+    {
+        let provider = RootProvider::new_http(rpc_url);
+        EvmSketchBuilder {
+            block: self.block,
+            genesis: self.genesis,
+            provider: provider.clone(),
+            anchor_prefetcher: HeaderAnchorBuilder::new(provider),
+        }
+    }
+}
+
+impl<P> EvmSketchBuilder<P, HeaderAnchorBuilder<P>>
+where
+    P: Provider<AnyNetwork>,
+{
+    pub fn cl_rpc_url(self, rpc_url: Url) -> EvmSketchBuilder<P, BeaconAnchorBuilder<P>> {
+        EvmSketchBuilder {
+            block: self.block,
+            genesis: self.genesis,
+            provider: self.provider,
+            anchor_prefetcher: BeaconAnchorBuilder::new(self.anchor_prefetcher, rpc_url),
+        }
+    }
+}
+
+impl<P, A> EvmSketchBuilder<P, A>
+where
+    P: Provider<AnyNetwork> + Clone,
+    A: AnchorBuilder,
+{
+    pub async fn build(self) -> Result<EvmSketch<P>, HostError> {
+        let anchor = self.anchor_prefetcher.build(self.block).await?;
+        let block_number = anchor.header().number;
+
+        let sketch = EvmSketch {
+            genesis: self.genesis,
+            anchor,
+            rpc_db: RpcDb::new(self.provider.clone(), block_number),
+            receipts: None,
+            provider: self.provider,
+        };
+
+        Ok(sketch)
+    }
+}
+
+impl Default for EvmSketchBuilder<(), ()> {
+    fn default() -> Self {
+        Self {
+            block: BlockId::default(),
+            genesis: Genesis::Mainnet,
+            provider: (),
+            anchor_prefetcher: (),
+        }
+    }
+}

--- a/crates/host-executor/src/sketch_builder.rs
+++ b/crates/host-executor/src/sketch_builder.rs
@@ -9,6 +9,7 @@ use crate::{
     EvmSketch, HostError,
 };
 
+/// A builder for [`EvmSketch`].
 #[derive(Debug)]
 pub struct EvmSketchBuilder<P, A> {
     block: BlockId,
@@ -18,11 +19,12 @@ pub struct EvmSketchBuilder<P, A> {
 }
 
 impl<P, A> EvmSketchBuilder<P, A> {
+    /// Sets the block on which the contract will be called.
     pub fn at_block<B: Into<BlockId>>(mut self, block: B) -> Self {
         self.block = block.into();
         self
     }
-
+    /// Sets the chain on which the contract will be called.
     pub fn with_genesis(mut self, genesis: Genesis) -> Self {
         self.genesis = genesis;
         self
@@ -30,6 +32,7 @@ impl<P, A> EvmSketchBuilder<P, A> {
 }
 
 impl EvmSketchBuilder<(), ()> {
+    /// Sets the Ethereum HTTP RPC endpoint that will be used.
     pub fn el_rpc_url(
         self,
         rpc_url: Url,
@@ -49,6 +52,7 @@ impl<P> EvmSketchBuilder<P, HeaderAnchorBuilder<P>>
 where
     P: Provider<AnyNetwork>,
 {
+    /// Sets the Beacon HTTP RPC endpoint that will be used.
     pub fn cl_rpc_url(self, rpc_url: Url) -> EvmSketchBuilder<P, BeaconAnchorBuilder<P>> {
         EvmSketchBuilder {
             block: self.block,
@@ -64,6 +68,7 @@ where
     P: Provider<AnyNetwork> + Clone,
     A: AnchorBuilder,
 {
+    /// Builds an [`EvmSketch`].
     pub async fn build(self) -> Result<EvmSketch<P>, HostError> {
         let anchor = self.anchor_prefetcher.build(self.block).await?;
         let block_number = anchor.header().number;

--- a/examples/events/client/src/main.rs
+++ b/examples/events/client/src/main.rs
@@ -4,10 +4,10 @@ sp1_zkvm::entrypoint!(main);
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolEvent;
 use events_client::{IERC20, WETH};
-use sp1_cc_client_executor::{io::EVMStateSketch, ClientExecutor};
+use sp1_cc_client_executor::{io::EvmSketchInput, ClientExecutor};
 
 pub fn main() {
-    let state_sketch = sp1_zkvm::io::read::<EVMStateSketch>();
+    let state_sketch = sp1_zkvm::io::read::<EvmSketchInput>();
 
     // Initialize the client executor with the state sketch.
     // This step also validates all of the storage against the provided state root.

--- a/examples/multiplexer/client/src/main.rs
+++ b/examples/multiplexer/client/src/main.rs
@@ -4,7 +4,7 @@ sp1_zkvm::entrypoint!(main);
 use alloy_primitives::{address, Address};
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolValue;
-use sp1_cc_client_executor::{io::EVMStateSketch, ClientExecutor, ContractInput};
+use sp1_cc_client_executor::{io::EvmSketchInput, ClientExecutor, ContractInput};
 
 sol! {
     /// Interface to the multiplexer contract. It gets the prices of many tokens, including
@@ -37,7 +37,7 @@ pub fn main() {
     // Read the state sketch from stdin. Use this during the execution in order to
     // access Ethereum state.
     let state_sketch_bytes = sp1_zkvm::io::read::<Vec<u8>>();
-    let state_sketch = bincode::deserialize::<EVMStateSketch>(&state_sketch_bytes).unwrap();
+    let state_sketch = bincode::deserialize::<EvmSketchInput>(&state_sketch_bytes).unwrap();
 
     // Initialize the client executor with the state sketch.
     // This step also validates all of the storage against the provided state root.

--- a/examples/uniswap/client/src/main.rs
+++ b/examples/uniswap/client/src/main.rs
@@ -4,7 +4,7 @@ sp1_zkvm::entrypoint!(main);
 use alloy_primitives::{address, Address};
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolValue;
-use sp1_cc_client_executor::{io::EVMStateSketch, ClientExecutor, ContractInput};
+use sp1_cc_client_executor::{io::EvmSketchInput, ClientExecutor, ContractInput};
 sol! {
     /// Simplified interface of the IUniswapV3PoolState interface.
     interface IUniswapV3PoolState {
@@ -20,7 +20,7 @@ pub fn main() {
     // Read the state sketch from stdin. Use this during the execution in order to
     // access Ethereum state.
     let state_sketch_bytes = sp1_zkvm::io::read::<Vec<u8>>();
-    let state_sketch = bincode::deserialize::<EVMStateSketch>(&state_sketch_bytes).unwrap();
+    let state_sketch = bincode::deserialize::<EvmSketchInput>(&state_sketch_bytes).unwrap();
 
     // Initialize the client executor with the state sketch.
     // This step also validates all of the storage against the provided state root.

--- a/examples/verify-quorum/client/src/main.rs
+++ b/examples/verify-quorum/client/src/main.rs
@@ -4,7 +4,7 @@ sp1_zkvm::entrypoint!(main);
 use alloy_primitives::{address, Address, Bytes, B256};
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolValue;
-use sp1_cc_client_executor::{io::EVMStateSketch, ClientExecutor, ContractInput};
+use sp1_cc_client_executor::{io::EvmSketchInput, ClientExecutor, ContractInput};
 
 sol! {
     /// Part of the SimpleStaking interface
@@ -22,7 +22,7 @@ pub fn main() {
     // Read the state sketch from stdin. Use this during the execution in order to
     // access Ethereum state.
     let state_sketch_bytes = sp1_zkvm::io::read::<Vec<u8>>();
-    let state_sketch = bincode::deserialize::<EVMStateSketch>(&state_sketch_bytes).unwrap();
+    let state_sketch = bincode::deserialize::<EvmSketchInput>(&state_sketch_bytes).unwrap();
 
     // Read messages and signatures from stdin.
     let messages = sp1_zkvm::io::read::<Vec<B256>>();


### PR DESCRIPTION
In this PR:

* Replace the header sent to the zkVM as input to an anchor that contains everything to validate the historical block
* Anchors builders in the host to prefetch anchors based on block hash or EIP-4788
* Refactoring
  * Now the main entrypoint is `EvmSketch`, that is used to prefetch data with `call()` or `get_logs()`, and is transformed to the inputs sent to the zkVM with `finalize()`.
  * A `EvmSketchBuider` to configure the sketch easily.
* Updated the examples