### PR TITLE
feat: add support for historical block proofs using consensus

### DIFF
--- a/crates/client-executor/src/lib.rs
+++ b/crates/client-executor/src/lib.rs
@@ -22,8 +22,8 @@ use rsp_primitives::genesis::Genesis;
 
 mod anchor;
 pub use anchor::{
-    get_beacon_root_from_state, rebuild_merkle_root, Anchor, BeaconAnchor, BeaconBlockField,
-    BeaconStateAnchor, BeaconWithHeaderAnchor, ChainedBeaconAnchor, HeaderAnchor,
+    get_beacon_root_from_state, rebuild_merkle_root, Anchor, BeaconAnchor, BeaconAnchorId,
+    BeaconBlockField, BeaconStateAnchor, BeaconWithHeaderAnchor, ChainedBeaconAnchor, HeaderAnchor,
     HISTORY_BUFFER_LENGTH,
 };
 

--- a/crates/client-executor/src/lib.rs
+++ b/crates/client-executor/src/lib.rs
@@ -108,7 +108,7 @@ impl IntoTxEnv<TxEnv> for &ContractInput {
 
 sol! {
     #[derive(Debug)]
-    enum AnchorType { BlockHash, BeaconRoot }
+    enum AnchorType { BlockHash, Eip4788, Consensus }
 
     /// Public values of a contract call.
     ///

--- a/crates/host-executor/src/anchor_builder.rs
+++ b/crates/host-executor/src/anchor_builder.rs
@@ -215,15 +215,24 @@ impl<P: Provider<AnyNetwork>, K: BeaconAnchorKind> BeaconAnchorBuilder<P, K> {
 }
 
 #[async_trait]
-impl<P: Provider<AnyNetwork>, K: BeaconAnchorKind + Sync> AnchorBuilder
-    for BeaconAnchorBuilder<P, K>
-{
+impl<P: Provider<AnyNetwork>> AnchorBuilder for BeaconAnchorBuilder<P, Eip4788BeaconAnchor> {
     async fn build<B: Into<BlockId> + Send>(&self, block_id: B) -> Result<Anchor, HostError> {
         let header = self.header_anchor_builder.get_header(block_id).await?;
         let anchor =
             self.build_beacon_anchor_with_header(&header, BeaconBlockField::BlockHash).await?;
 
-        Ok(Anchor::Beacon(anchor))
+        Ok(Anchor::Eip4788(anchor))
+    }
+}
+
+#[async_trait]
+impl<P: Provider<AnyNetwork>> AnchorBuilder for BeaconAnchorBuilder<P, ConsensusBeaconAnchor> {
+    async fn build<B: Into<BlockId> + Send>(&self, block_id: B) -> Result<Anchor, HostError> {
+        let header = self.header_anchor_builder.get_header(block_id).await?;
+        let anchor =
+            self.build_beacon_anchor_with_header(&header, BeaconBlockField::BlockHash).await?;
+
+        Ok(Anchor::Consensus(anchor))
     }
 }
 
@@ -360,7 +369,7 @@ impl<P: Provider<AnyNetwork>> AnchorBuilder for ChainedBeaconAnchorBuilder<P> {
             );
         }
 
-        Ok(Anchor::Chained(ChainedBeaconAnchor::new(execution_anchor, state_anchors)))
+        Ok(Anchor::ChainedEip4788(ChainedBeaconAnchor::new(execution_anchor, state_anchors)))
     }
 }
 

--- a/crates/host-executor/src/lib.rs
+++ b/crates/host-executor/src/lib.rs
@@ -2,7 +2,8 @@ pub use rsp_primitives::genesis::Genesis;
 
 mod anchor_builder;
 pub use anchor_builder::{
-    AnchorBuilder, BeaconAnchorBuilder, ChainedBeaconAnchorBuilder, HeaderAnchorBuilder,
+    AnchorBuilder, BeaconAnchorBuilder, BeaconAnchorKind, ChainedBeaconAnchorBuilder,
+    ConsensusBeaconAnchor, Eip4788BeaconAnchor, HeaderAnchorBuilder,
 };
 
 mod beacon;

--- a/crates/host-executor/tests/anchor.rs
+++ b/crates/host-executor/tests/anchor.rs
@@ -1,5 +1,5 @@
 use alloy_provider::{network::AnyNetwork, RootProvider};
-use revm_primitives::b256;
+use revm_primitives::{b256, uint};
 use sp1_cc_host_executor::{
     AnchorBuilder, BeaconAnchorBuilder, ChainedBeaconAnchorBuilder, HeaderAnchorBuilder,
 };
@@ -21,6 +21,8 @@ async fn test_deneb_beacon_anchor() {
 
     let anchor = beacon_anchor_builder.build(22300000).await.unwrap();
     let resolved = anchor.resolve();
+
+    assert_eq!(resolved.id, uint!(1745028935_U256)); // Timestamp
 
     assert_eq!(
         resolved.hash,
@@ -45,6 +47,35 @@ async fn test_electra_beacon_anchor() {
 
     let anchor = beacon_anchor_builder.build(22500000).await.unwrap();
     let resolved = anchor.resolve();
+
+    assert_eq!(resolved.id, uint!(1747451519_U256)); // Timestamp
+
+    assert_eq!(
+        resolved.hash,
+        b256!("0xd1fa05159386e8ee0ef3a158a4e37a0a807de7d7e1e2d016f364cec3efcb88f9")
+    )
+}
+
+#[tokio::test]
+async fn test_consensus_beacon_anchor() {
+    dotenv::dotenv().ok();
+
+    let eth_rpc_url =
+        std::env::var("ETH_RPC_URL").unwrap_or_else(|_| panic!("Missing ETH_RPC_URL"));
+    let beacon_rpc_url =
+        std::env::var("BEACON_RPC_URL").unwrap_or_else(|_| panic!("Missing BEACON_RPC_URL"));
+    let provider = RootProvider::<AnyNetwork>::new_http(eth_rpc_url.parse().unwrap());
+
+    let beacon_anchor_builder = BeaconAnchorBuilder::new(
+        HeaderAnchorBuilder::new(provider),
+        beacon_rpc_url.parse().unwrap(),
+    )
+    .into_consensus();
+
+    let anchor = beacon_anchor_builder.build(22500000).await.unwrap();
+    let resolved = anchor.resolve();
+
+    assert_eq!(resolved.id, uint!(11718957_U256)); // Slot
 
     assert_eq!(
         resolved.hash,


### PR DESCRIPTION
Allow to configure the `EvmSketchBuilder` to creates an anchor that contains a slot as ID. This may be useful because it's easy to verify in contexts with direct access to state of the beacon chain.