### PR TITLE
fix: execute OP stack transactions with OpEvm

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,6 +30,7 @@ jobs:
           - multiplexer
           - verify-quorum
           - example-deploy
+          - optimism
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,6 +51,7 @@ jobs:
           echo "ETH_RPC_URL=${{secrets.ETH_RPC_URL}}" >> $GITHUB_ENV
           echo "BEACON_RPC_URL=${{secrets.BEACON_RPC_URL}}" >> $GITHUB_ENV
           echo "ETH_SEPOLIA_RPC_URL=${{secrets.ETH_SEPOLIA_RPC_URL}}" >> $GITHUB_ENV
+          echo "OPTIMISM_RPC_URL=${{secrets.OPTIMISM_RPC_URL}}" >> $GITHUB_ENV
 
       - name: Run ${{ matrix.example }}
         uses: actions-rs/cargo@v1   

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4243,6 +4243,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "optimism"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "alloy-primitives 1.0.0",
+ "alloy-provider",
+ "alloy-rpc-types",
+ "alloy-sol-macro",
+ "alloy-sol-types",
+ "bincode",
+ "dotenv",
+ "eyre",
+ "sp1-build",
+ "sp1-cc-client-executor",
+ "sp1-cc-host-executor",
+ "sp1-sdk",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "optimism-client"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives 1.0.0",
+ "alloy-sol-macro",
+ "alloy-sol-types",
+ "bincode",
+ "sp1-cc-client-executor",
+ "sp1-zkvm",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6069,7 +6102,7 @@ dependencies = [
 [[package]]
 name = "rsp-client-executor"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?rev=34f9ee4898e6727ddc9ce09fea0674bac7aefe8c#34f9ee4898e6727ddc9ce09fea0674bac7aefe8c"
+source = "git+https://github.com/succinctlabs/rsp?rev=8308457c8a4ebf384b6e428d904c68ba6d8ff731#8308457c8a4ebf384b6e428d904c68ba6d8ff731"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -6100,7 +6133,7 @@ dependencies = [
 [[package]]
 name = "rsp-mpt"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?rev=34f9ee4898e6727ddc9ce09fea0674bac7aefe8c#34f9ee4898e6727ddc9ce09fea0674bac7aefe8c"
+source = "git+https://github.com/succinctlabs/rsp?rev=8308457c8a4ebf384b6e428d904c68ba6d8ff731#8308457c8a4ebf384b6e428d904c68ba6d8ff731"
 dependencies = [
  "alloy-primitives 1.0.0",
  "alloy-rlp",
@@ -6114,7 +6147,7 @@ dependencies = [
 [[package]]
 name = "rsp-primitives"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?rev=34f9ee4898e6727ddc9ce09fea0674bac7aefe8c#34f9ee4898e6727ddc9ce09fea0674bac7aefe8c"
+source = "git+https://github.com/succinctlabs/rsp?rev=8308457c8a4ebf384b6e428d904c68ba6d8ff731#8308457c8a4ebf384b6e428d904c68ba6d8ff731"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types",
@@ -6131,7 +6164,7 @@ dependencies = [
 [[package]]
 name = "rsp-rpc-db"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?rev=34f9ee4898e6727ddc9ce09fea0674bac7aefe8c#34f9ee4898e6727ddc9ce09fea0674bac7aefe8c"
+source = "git+https://github.com/succinctlabs/rsp?rev=8308457c8a4ebf384b6e428d904c68ba6d8ff731#8308457c8a4ebf384b6e428d904c68ba6d8ff731"
 dependencies = [
  "alloy-primitives 1.0.0",
  "alloy-provider",
@@ -6148,7 +6181,7 @@ dependencies = [
 [[package]]
 name = "rsp-witness-db"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?rev=34f9ee4898e6727ddc9ce09fea0674bac7aefe8c#34f9ee4898e6727ddc9ce09fea0674bac7aefe8c"
+source = "git+https://github.com/succinctlabs/rsp?rev=8308457c8a4ebf384b6e428d904c68ba6d8ff731#8308457c8a4ebf384b6e428d904c68ba6d8ff731"
 dependencies = [
  "alloy-primitives 1.0.0",
  "reth-storage-errors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-op-evm"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427bfde7779a82607cc97df6c6e634dc8b25a1412d03d0e26a2ef27b83c3856a"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-op-hardforks",
+ "alloy-primitives 1.0.0",
+ "auto_impl",
+ "op-alloy-consensus",
+ "op-revm",
+ "revm",
+]
+
+[[package]]
+name = "alloy-op-hardforks"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a45f2af91a348e5d22dbb3589d821d2e83d2e65b54c14c3f9e8e9c6903fc09"
+dependencies = [
+ "alloy-hardforks",
+ "auto_impl",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,9 +1511,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
 name = "byteorder"
@@ -1521,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
 dependencies = [
  "serde",
 ]
@@ -1759,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1887,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.6"
+version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
+checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
  "nix",
  "windows-sys 0.59.0",
@@ -3547,12 +3574,12 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -3878,9 +3905,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4133,6 +4160,24 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f410c4bd213df7c4963828b45a1e201d119b5c223d12468ad8e393e655167eee"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives 1.0.0",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "derive_more 2.0.1",
+ "op-alloy-consensus",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4730,9 +4775,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
  "syn 2.0.100",
@@ -5453,6 +5498,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-optimism-chainspec"
+version = "1.3.10"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-hardforks",
+ "alloy-primitives 1.0.0",
+ "derive_more 2.0.1",
+ "op-alloy-rpc-types",
+ "reth-chainspec",
+ "reth-ethereum-forks",
+ "reth-network-peers",
+ "reth-optimism-forks",
+ "reth-optimism-primitives",
+ "reth-primitives-traits",
+ "serde_json",
+]
+
+[[package]]
+name = "reth-optimism-consensus"
+version = "1.3.10"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives 1.0.0",
+ "alloy-trie",
+ "op-alloy-consensus",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-execution-types",
+ "reth-optimism-forks",
+ "reth-optimism-primitives",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-trie-common",
+ "revm",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "reth-optimism-evm"
+version = "1.3.10"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-op-evm",
+ "alloy-primitives 1.0.0",
+ "op-alloy-consensus",
+ "op-revm",
+ "reth-chainspec",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-optimism-chainspec",
+ "reth-optimism-consensus",
+ "reth-optimism-forks",
+ "reth-optimism-primitives",
+ "reth-primitives-traits",
+ "revm",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "reth-optimism-forks"
+version = "1.3.10"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
+dependencies = [
+ "alloy-op-hardforks",
+ "alloy-primitives 1.0.0",
+ "once_cell",
+ "reth-ethereum-forks",
+]
+
+[[package]]
+name = "reth-optimism-primitives"
+version = "1.3.10"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives 1.0.0",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "bytes",
+ "derive_more 2.0.1",
+ "op-alloy-consensus",
+ "op-revm",
+ "rand 0.8.5",
+ "reth-codecs",
+ "reth-primitives-traits",
+ "revm-context",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "reth-primitives"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
@@ -5968,6 +6120,8 @@ dependencies = [
  "alloy-rpc-types",
  "eyre",
  "reth-chainspec",
+ "reth-optimism-chainspec",
+ "reth-optimism-forks",
  "reth-primitives-traits",
  "reth-trie",
  "serde",
@@ -6201,9 +6355,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
 dependencies = [
  "sdd",
 ]
@@ -6260,9 +6414,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "rand 0.8.5",
  "secp256k1-sys 0.10.1",
@@ -6318,7 +6472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6415,9 +6569,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -6667,6 +6821,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
+ "alloy-op-evm",
  "alloy-primitives 1.0.0",
  "alloy-rpc-types",
  "alloy-rpc-types-eth",
@@ -6674,11 +6829,16 @@ dependencies = [
  "alloy-sol-types",
  "alloy-trie",
  "eyre",
+ "op-revm",
  "reth-chainspec",
  "reth-consensus",
  "reth-ethereum-consensus",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-optimism-chainspec",
+ "reth-optimism-consensus",
+ "reth-optimism-evm",
+ "reth-optimism-primitives",
  "reth-primitives",
  "revm",
  "revm-primitives",
@@ -6712,6 +6872,8 @@ dependencies = [
  "eyre",
  "reqwest",
  "reth-chainspec",
+ "reth-optimism-primitives",
+ "reth-primitives",
  "revm",
  "revm-primitives",
  "rsp-client-executor",
@@ -7087,9 +7249,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.0.3"
+version = "5.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463909ee4714c1409d8d169bafe7a61a10b4c727a3c715aff1c9b3e93c7d698a"
+checksum = "4e05659d72bc760a14e2a9fb801075d5577453318316b2bd1998e0d2781cbc1b"
 dependencies = [
  "alloy-primitives 1.0.0",
  "anyhow",
@@ -7998,9 +8160,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
@@ -8123,7 +8285,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "reth-primitives",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "sp1-build",
  "sp1-cc-client-executor",
  "sp1-cc-host-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ members = [
     "examples/multiplexer/client",
     "examples/events/host",
     "examples/events/client",
+    "examples/optimism/host",
+    "examples/optimism/client",
     "examples/verify-quorum/host",
     "examples/verify-quorum/client",
     "crates/client-executor",
@@ -48,11 +50,11 @@ sp1-zkvm = "5.0.0"
 sp1-build = "5.0.0"
 
 # rsp
-rsp-rpc-db = { git = "https://github.com/succinctlabs/rsp", rev = "34f9ee4898e6727ddc9ce09fea0674bac7aefe8c" }
-rsp-witness-db = { git = "https://github.com/succinctlabs/rsp", rev = "34f9ee4898e6727ddc9ce09fea0674bac7aefe8c" }
-rsp-primitives = { git = "https://github.com/succinctlabs/rsp", rev = "34f9ee4898e6727ddc9ce09fea0674bac7aefe8c" }
-rsp-client-executor = { git = "https://github.com/succinctlabs/rsp", rev = "34f9ee4898e6727ddc9ce09fea0674bac7aefe8c" }
-rsp-mpt = { git = "https://github.com/succinctlabs/rsp", rev = "34f9ee4898e6727ddc9ce09fea0674bac7aefe8c" }
+rsp-rpc-db = { git = "https://github.com/succinctlabs/rsp", rev = "8308457c8a4ebf384b6e428d904c68ba6d8ff731" }
+rsp-witness-db = { git = "https://github.com/succinctlabs/rsp", rev = "8308457c8a4ebf384b6e428d904c68ba6d8ff731" }
+rsp-primitives = { git = "https://github.com/succinctlabs/rsp", rev = "8308457c8a4ebf384b6e428d904c68ba6d8ff731" }
+rsp-client-executor = { git = "https://github.com/succinctlabs/rsp", rev = "8308457c8a4ebf384b6e428d904c68ba6d8ff731" }
+rsp-mpt = { git = "https://github.com/succinctlabs/rsp", rev = "8308457c8a4ebf384b6e428d904c68ba6d8ff731" }
 
 # rsp-rpc-db = { path = "../rsp/crates/storage/rpc-db" }
 # rsp-witness-db = { path = "../rsp/crates/storage/witness-db" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10"
 ] }
 reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10", default-features = false }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10", default-features = false }
+reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10", default-features = false }
+reth-optimism-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10", default-features = false }
+reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10", default-features = false }
+reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10", default-features = false }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10", default-features = false }
 reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.10", default-features = false, features = [
     "std",
@@ -93,6 +97,7 @@ revm = { version = "22.0.1", features = [
 revm-primitives = { version = "18.0.0", features = [
     "std",
 ], default-features = false }
+op-revm = { version = "3.0.2", default-features = false }
 
 # alloy
 alloy-primitives = "1.0"
@@ -117,6 +122,7 @@ alloy-sol-macro = { version = "1.0" }
 alloy = { version = "0.14.0" }
 
 alloy-evm = { version = "0.4.0", default-features = false }
+alloy-op-evm = { version = "0.4.0", default-features = false }
 
 sha2 = "0.10.8"
 beacon-api-client = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "ba43147eb71b07e21e156e2904549405f87bc9a6" }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ let state_sketch = bincode::deserialize::<EVMStateSketch>(&state_sketch_bytes).u
 
 // Initialize the client executor with the state sketch.
 // This step also validates all of the storage against the provided state root.
-let executor = ClientExecutor::new(state_sketch).unwrap();
+let executor = ClientExecutor::eth(state_sketch).unwrap();
 
 // Execute the slot0 call using the client executor.
 let slot0_call = IUniswapV3PoolState::slot0Call {};

--- a/crates/client-executor/Cargo.toml
+++ b/crates/client-executor/Cargo.toml
@@ -56,6 +56,7 @@ optimism = [
     "dep:op-revm",
     "dep:reth-optimism-chainspec",
     "dep:reth-optimism-consensus",
+    "dep:reth-optimism-evm",
     "dep:reth-optimism-primitives",
     "rsp-primitives/optimism"
 ]

--- a/crates/client-executor/Cargo.toml
+++ b/crates/client-executor/Cargo.toml
@@ -28,10 +28,15 @@ reth-ethereum-consensus.workspace = true
 reth-evm.workspace = true
 reth-evm-ethereum.workspace = true
 reth-primitives.workspace = true
+reth-optimism-chainspec = { workspace = true, optional = true }
+reth-optimism-consensus = { workspace = true, optional = true }
+reth-optimism-evm = { workspace = true, optional = true }
+reth-optimism-primitives = { workspace = true, optional = true, features = ["serde", "serde-bincode-compat"]}
 
 # revm
 revm.workspace = true
 revm-primitives.workspace = true
+op-revm = { workspace = true, optional = true }
 
 # alloy
 alloy-consensus = { workspace = true, features = ["serde", "serde-bincode-compat"] }
@@ -41,7 +46,16 @@ alloy-primitives.workspace = true
 alloy-rpc-types = { workspace = true }
 alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
 alloy-evm.workspace = true
+alloy-op-evm = { workspace = true, optional = true }
 alloy-serde.workspace = true
 alloy-trie.workspace = true
 
-[dev-dependencies]
+[features]
+optimism = [
+    "dep:alloy-op-evm",
+    "dep:op-revm",
+    "dep:reth-optimism-chainspec",
+    "dep:reth-optimism-consensus",
+    "dep:reth-optimism-primitives",
+    "rsp-primitives/optimism"
+]

--- a/crates/client-executor/src/io.rs
+++ b/crates/client-executor/src/io.rs
@@ -78,7 +78,7 @@ impl WitnessInput for EvmSketchInput {
 }
 
 pub trait Primitives: NodePrimitives {
-    type ChainSpec;
+    type ChainSpec: Debug;
     type HaltReason: Debug;
 
     fn build_spec(genesis: &Genesis) -> Result<Arc<Self::ChainSpec>, ClientError>;
@@ -169,12 +169,13 @@ impl Primitives for reth_optimism_primitives::OpPrimitives {
     ) -> Result<ResultAndState<Self::HaltReason>, String> {
         use op_revm::{DefaultOp, OpBuilder};
 
-        let EvmEnv { cfg_env, mut block_env, .. } =
+        let EvmEnv { mut cfg_env, mut block_env, .. } =
             reth_optimism_evm::OpEvmConfig::optimism(chain_spec).evm_env(header);
 
         // Set the base fee to 0 to enable 0 gas price transactions.
         block_env.basefee = 0;
         block_env.difficulty = difficulty;
+        cfg_env.disable_nonce_check = true;
 
         let evm = op_revm::OpContext::op()
             .with_db(db)

--- a/crates/client-executor/src/io.rs
+++ b/crates/client-executor/src/io.rs
@@ -1,16 +1,27 @@
-use std::iter::once;
+use std::{fmt::Debug, iter::once, sync::Arc};
 
 use alloy_consensus::ReceiptEnvelope;
-use reth_primitives::Header;
-use revm::state::Bytecode;
+use alloy_evm::{Database, Evm};
+use reth_chainspec::ChainSpec;
+use reth_consensus::{ConsensusError, HeaderValidator};
+use reth_ethereum_consensus::EthBeaconConsensus;
+use reth_evm::{ConfigureEvm, EthEvm, EvmEnv};
+use reth_evm_ethereum::EthEvmConfig;
+use reth_primitives::{EthPrimitives, Header, NodePrimitives, SealedHeader};
+use revm::{
+    context::result::{HaltReason, ResultAndState},
+    inspector::NoOpInspector,
+    state::Bytecode,
+    Context, MainBuilder, MainContext,
+};
 use revm_primitives::{Address, HashMap, B256, U256};
-use rsp_client_executor::io::WitnessInput;
+use rsp_client_executor::{error::ClientError, io::WitnessInput};
 use rsp_mpt::EthereumState;
 use rsp_primitives::genesis::Genesis;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use crate::Anchor;
+use crate::{Anchor, ContractInput};
 
 /// Information about how the contract executions accessed state, which is needed to execute the
 /// contract in SP1.
@@ -63,5 +74,119 @@ impl WitnessInput for EvmSketchInput {
     #[inline(always)]
     fn headers(&self) -> impl Iterator<Item = &Header> {
         once(self.anchor.header()).chain(self.ancestor_headers.iter())
+    }
+}
+
+pub trait Primitives: NodePrimitives {
+    type ChainSpec;
+    type HaltReason: Debug;
+
+    fn build_spec(genesis: &Genesis) -> Result<Arc<Self::ChainSpec>, ClientError>;
+
+    fn validate_header(
+        header: &SealedHeader,
+        chain_spec: Arc<Self::ChainSpec>,
+    ) -> Result<(), ConsensusError>;
+
+    fn transact<DB>(
+        input: &ContractInput,
+        db: DB,
+        header: &Header,
+        difficulty: U256,
+        chain_spec: Arc<Self::ChainSpec>,
+    ) -> Result<ResultAndState<Self::HaltReason>, String>
+    where
+        DB: Database;
+}
+
+impl Primitives for EthPrimitives {
+    type ChainSpec = ChainSpec;
+    type HaltReason = HaltReason;
+
+    fn build_spec(genesis: &Genesis) -> Result<Arc<Self::ChainSpec>, ClientError> {
+        Ok(Arc::new(ChainSpec::try_from(genesis).unwrap()))
+    }
+
+    fn validate_header(
+        header: &SealedHeader,
+        chain_spec: Arc<Self::ChainSpec>,
+    ) -> Result<(), ConsensusError> {
+        let validator = EthBeaconConsensus::new(chain_spec);
+        validator.validate_header(header)
+    }
+
+    fn transact<DB: Database>(
+        input: &ContractInput,
+        db: DB,
+        header: &Header,
+        difficulty: U256,
+        chain_spec: Arc<Self::ChainSpec>,
+    ) -> Result<ResultAndState<Self::HaltReason>, String> {
+        let EvmEnv { cfg_env, mut block_env, .. } = EthEvmConfig::new(chain_spec).evm_env(header);
+
+        // Set the base fee to 0 to enable 0 gas price transactions.
+        block_env.basefee = 0;
+        block_env.difficulty = difficulty;
+
+        let evm = Context::mainnet()
+            .with_db(db)
+            .with_cfg(cfg_env)
+            .with_block(block_env)
+            .modify_tx_chained(|tx_env| {
+                tx_env.gas_limit = header.gas_limit;
+            })
+            .build_mainnet_with_inspector(NoOpInspector {});
+
+        let mut evm = EthEvm::new(evm, false);
+
+        evm.transact(input).map_err(|err| err.to_string())
+    }
+}
+
+#[cfg(feature = "optimism")]
+impl Primitives for reth_optimism_primitives::OpPrimitives {
+    type ChainSpec = reth_optimism_chainspec::OpChainSpec;
+    type HaltReason = op_revm::OpHaltReason;
+
+    fn build_spec(genesis: &Genesis) -> Result<Arc<Self::ChainSpec>, ClientError> {
+        Ok(Arc::new(reth_optimism_chainspec::OpChainSpec::try_from(genesis).unwrap()))
+    }
+
+    fn validate_header(
+        header: &SealedHeader,
+        chain_spec: Arc<Self::ChainSpec>,
+    ) -> Result<(), ConsensusError> {
+        let validator = reth_optimism_consensus::OpBeaconConsensus::new(chain_spec);
+        validator.validate_header(header)
+    }
+
+    fn transact<DB: Database>(
+        input: &ContractInput,
+        db: DB,
+        header: &Header,
+        difficulty: U256,
+        chain_spec: Arc<Self::ChainSpec>,
+    ) -> Result<ResultAndState<Self::HaltReason>, String> {
+        use op_revm::{DefaultOp, OpBuilder};
+
+        let EvmEnv { cfg_env, mut block_env, .. } =
+            reth_optimism_evm::OpEvmConfig::optimism(chain_spec).evm_env(header);
+
+        // Set the base fee to 0 to enable 0 gas price transactions.
+        block_env.basefee = 0;
+        block_env.difficulty = difficulty;
+
+        let evm = op_revm::OpContext::op()
+            .with_db(db)
+            .with_cfg(cfg_env)
+            .with_block(block_env)
+            .modify_tx_chained(|tx_env| {
+                tx_env.base.gas_limit = header.gas_limit;
+            })
+            .build_op_with_inspector(NoOpInspector {});
+
+        let mut evm = alloy_op_evm::OpEvm::new(evm, false);
+
+        evm.transact(input).map_err(|err| err.to_string())
     }
 }

--- a/crates/client-executor/src/lib.rs
+++ b/crates/client-executor/src/lib.rs
@@ -107,11 +107,7 @@ impl IntoTxEnv<TxEnv> for &ContractInput {
 #[cfg(feature = "optimism")]
 impl IntoTxEnv<op_revm::OpTransaction<TxEnv>> for &ContractInput {
     fn into_tx_env(self) -> op_revm::OpTransaction<TxEnv> {
-        op_revm::OpTransaction {
-            base: self.into_tx_env(),
-            enveloped_tx: None,
-            deposit: Default::default(),
-        }
+        op_revm::OpTransaction { base: self.into_tx_env(), ..Default::default() }
     }
 }
 

--- a/crates/host-executor/Cargo.toml
+++ b/crates/host-executor/Cargo.toml
@@ -30,6 +30,8 @@ rsp-mpt.workspace = true
 
 # reth
 reth-chainspec.workspace = true
+reth-primitives.workspace = true
+reth-optimism-primitives = { workspace = true, optional = true, features = ["serde", "serde-bincode-compat"]}
 
 # revm
 revm.workspace = true
@@ -53,3 +55,8 @@ alloy-primitives.workspace = true
 dotenv.workspace = true
 tracing-subscriber = "0.3.18"
 bincode = "1.3.3"
+
+[features]
+optimism = [
+    "dep:reth-optimism-primitives",
+]

--- a/crates/host-executor/src/sketch_builder.rs
+++ b/crates/host-executor/src/sketch_builder.rs
@@ -63,7 +63,7 @@ impl<PT> EvmSketchBuilder<(), PT, ()> {
 impl<P, A> EvmSketchBuilder<P, EthPrimitives, A> {
     /// Configures the [`EvmSketch`] for OP Stack.
     ///
-    /// Note: On the client, the executor should be crearted with [`ClientExecutor::optimism()`]
+    /// Note: On the client, the executor should be created with [`ClientExecutor::optimism()`]
     ///
     /// [`ClientExecutor::optimism()`]: sp1_cc_client_executor::ClientExecutor::optimism
     pub fn optimism(self) -> EvmSketchBuilder<P, reth_optimism_primitives::OpPrimitives, A> {

--- a/crates/host-executor/src/sketch_builder.rs
+++ b/crates/host-executor/src/sketch_builder.rs
@@ -43,11 +43,8 @@ impl<PT> EvmSketchBuilder<(), PT, ()> {
     pub fn el_rpc_url(
         self,
         rpc_url: Url,
-    ) -> EvmSketchBuilder<
-        RootProvider<AnyNetwork>,
-        EthPrimitives,
-        HeaderAnchorBuilder<RootProvider<AnyNetwork>>,
-    > {
+    ) -> EvmSketchBuilder<RootProvider<AnyNetwork>, PT, HeaderAnchorBuilder<RootProvider<AnyNetwork>>>
+    {
         let provider = RootProvider::new_http(rpc_url);
         EvmSketchBuilder {
             block: self.block,
@@ -63,13 +60,28 @@ impl<PT> EvmSketchBuilder<(), PT, ()> {
 impl<P, A> EvmSketchBuilder<P, EthPrimitives, A> {
     /// Configures the [`EvmSketch`] for OP Stack.
     ///
-    /// Note: On the client, the executor should be created with [`ClientExecutor::optimism()`]
+    /// Note: the sketch must be configured with a OP stack genesis with [`with_genesis()`]. On the
+    /// client, the executor must be created with [`ClientExecutor::optimism()`].
     ///
+    /// [`with_genesis()`]: EvmSketchBuilder::with_genesis
     /// [`ClientExecutor::optimism()`]: sp1_cc_client_executor::ClientExecutor::optimism
     pub fn optimism(self) -> EvmSketchBuilder<P, reth_optimism_primitives::OpPrimitives, A> {
         EvmSketchBuilder {
             block: self.block,
             genesis: self.genesis,
+            provider: self.provider,
+            anchor_builder: self.anchor_builder,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Configures the [`EvmSketch`] for OP Mainnet..
+    pub fn optimism_mainnet(
+        self,
+    ) -> EvmSketchBuilder<P, reth_optimism_primitives::OpPrimitives, A> {
+        EvmSketchBuilder {
+            block: self.block,
+            genesis: Genesis::OpMainnet,
             provider: self.provider,
             anchor_builder: self.anchor_builder,
             phantom: PhantomData,

--- a/crates/host-executor/src/test.rs
+++ b/crates/host-executor/src/test.rs
@@ -169,7 +169,7 @@ async fn test_e2e<C: SolCall + Clone>(
     // Now that we've executed all of the calls, get the `EVMStateSketch` from the host executor.
     let state_sketch = sketch.finalize().await?;
 
-    let client_executor = ClientExecutor::new(&state_sketch)?;
+    let client_executor = ClientExecutor::eth(&state_sketch)?;
     let contract_input = ContractInput::new_call(contract_address, caller_address, calldata);
 
     let public_values = client_executor.execute(contract_input)?;

--- a/examples/events/client/src/main.rs
+++ b/examples/events/client/src/main.rs
@@ -11,7 +11,7 @@ pub fn main() {
 
     // Initialize the client executor with the state sketch.
     // This step also validates all of the storage against the provided state root.
-    let executor = ClientExecutor::new(&state_sketch).unwrap();
+    let executor = ClientExecutor::eth(&state_sketch).unwrap();
     let filter = Filter::new().address(WETH).event(IERC20::Transfer::SIGNATURE);
     let logs = executor.get_logs::<IERC20::Transfer>(filter).unwrap();
 

--- a/examples/multiplexer/client/src/main.rs
+++ b/examples/multiplexer/client/src/main.rs
@@ -41,7 +41,7 @@ pub fn main() {
 
     // Initialize the client executor with the state sketch.
     // This step also validates all of the storage against the provided state root.
-    let executor = ClientExecutor::new(&state_sketch).unwrap();
+    let executor = ClientExecutor::eth(&state_sketch).unwrap();
 
     // Execute the getRates call using the client executor.
     let calldata = IOracleHelper::getRatesCall { collaterals: COLLATERALS.to_vec() };

--- a/examples/optimism/client/Cargo.toml
+++ b/examples/optimism/client/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "optimism-client"
+description = ""
+edition = "2021"
+
+[dependencies]
+# workspace
+sp1-cc-client-executor = { path = "../../../crates/client-executor", features = ["optimism"] }
+
+# alloy
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-sol-types.workspace = true
+alloy-sol-macro.workspace = true
+
+# sp1
+sp1-zkvm.workspace = true
+
+# misc
+bincode = "1.3.3"

--- a/examples/optimism/client/src/main.rs
+++ b/examples/optimism/client/src/main.rs
@@ -1,0 +1,30 @@
+use alloy_primitives::{address, Address};
+use alloy_sol_macro::sol;
+use alloy_sol_types::SolValue;
+use sp1_cc_client_executor::{io::EvmSketchInput, ClientExecutor, ContractInput};
+
+const CONTRACT: Address = address!("0x420000000000000000000000000000000000000F");
+
+sol! {
+    interface IGasPriceOracle {
+        function gasPrice() external view returns (uint256);
+    }
+}
+
+pub fn main() {
+    // Read the state sketch from stdin. Use this during the execution in order to
+    // access Ethereum state.
+    let state_sketch_bytes = sp1_zkvm::io::read::<Vec<u8>>();
+    let state_sketch = bincode::deserialize::<EvmSketchInput>(&state_sketch_bytes).unwrap();
+
+    // Initialize the client executor with the state sketch.
+    // This step also validates all of the storage against the provided state root.
+    let executor = ClientExecutor::optimism(&state_sketch).unwrap();
+
+    // Execute the gasPrice call using the client executor.
+    let call = ContractInput::new_call(CONTRACT, Address::default(), IGasPriceOracle::gasPriceCall);
+    let public_vals = executor.execute(call).unwrap();
+
+    // Commit the abi-encoded output.
+    sp1_zkvm::io::commit_slice(&public_vals.abi_encode());
+}

--- a/examples/optimism/client/src/main.rs
+++ b/examples/optimism/client/src/main.rs
@@ -3,11 +3,11 @@ use alloy_sol_macro::sol;
 use alloy_sol_types::SolValue;
 use sp1_cc_client_executor::{io::EvmSketchInput, ClientExecutor, ContractInput};
 
-const CONTRACT: Address = address!("0x420000000000000000000000000000000000000F");
+const CONTRACT: Address = address!("0x4200000000000000000000000000000000000015");
 
 sol! {
-    interface IGasPriceOracle {
-        function gasPrice() external view returns (uint256);
+    interface IL1Block {
+        function basefee() external view returns (uint256);
     }
 }
 
@@ -22,7 +22,7 @@ pub fn main() {
     let executor = ClientExecutor::optimism(&state_sketch).unwrap();
 
     // Execute the gasPrice call using the client executor.
-    let call = ContractInput::new_call(CONTRACT, Address::default(), IGasPriceOracle::gasPriceCall);
+    let call = ContractInput::new_call(CONTRACT, Address::default(), IL1Block::basefeeCall);
     let public_vals = executor.execute(call).unwrap();
 
     // Commit the abi-encoded output.

--- a/examples/optimism/host/Cargo.toml
+++ b/examples/optimism/host/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+version = "0.1.0"
+name = "optimism"
+edition = "2021"
+
+[dependencies]
+# workspace
+sp1-cc-host-executor = { path = "../../../crates/host-executor", features = ["optimism"] }
+sp1-cc-client-executor = { path = "../../../crates/client-executor" }
+
+alloy-primitives.workspace = true
+alloy-sol-types.workspace = true
+alloy-rpc-types.workspace = true
+alloy-sol-macro.workspace = true
+alloy-provider.workspace = true
+alloy.workspace = true
+dotenv.workspace = true
+
+# misc:
+url.workspace = true
+tokio.workspace = true
+eyre.workspace = true
+bincode.workspace = true
+
+# sp1
+sp1-sdk.workspace = true
+
+[build-dependencies]
+sp1-build.workspace = true

--- a/examples/optimism/host/build.rs
+++ b/examples/optimism/host/build.rs
@@ -1,0 +1,5 @@
+use sp1_build::build_program;
+
+fn main() {
+    build_program("../client");
+}

--- a/examples/optimism/host/src/main.rs
+++ b/examples/optimism/host/src/main.rs
@@ -1,0 +1,69 @@
+use alloy::sol;
+use alloy_primitives::{address, Address};
+use alloy_rpc_types::BlockNumberOrTag;
+use alloy_sol_types::{SolCall, SolType};
+use sp1_cc_client_executor::ContractPublicValues;
+use sp1_cc_host_executor::EvmSketch;
+use sp1_sdk::{include_elf, utils, ProverClient, SP1Stdin};
+use url::Url;
+
+const CONTRACT: Address = address!("0x420000000000000000000000000000000000000F");
+
+sol! {
+    interface IGasPriceOracle {
+        function gasPrice() external view returns (uint256);
+    }
+}
+
+/// The ELF we want to execute inside the zkVM.
+const ELF: &[u8] = include_elf!("optimism-client");
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    dotenv::dotenv().ok();
+
+    // Setup logging.
+    utils::setup_logger();
+
+    // Prepare the host executor.
+    //
+    // Use `OPTIMISM_RPC_URL` to get all of the necessary state for the smart contract call.
+    let rpc_url = std::env::var("OPTIMISM_RPC_URL")
+        .unwrap_or_else(|_| panic!("Missing OPTIMISM_RPC_URL in env"));
+    let sketch = EvmSketch::builder()
+        .optimism_mainnet()
+        .at_block(BlockNumberOrTag::Safe)
+        .el_rpc_url(Url::parse(&rpc_url)?)
+        .build()
+        .await?;
+
+    sketch.call(CONTRACT, Address::default(), IGasPriceOracle::gasPriceCall).await?;
+
+    // Now that we've executed all of the calls, get the `EvmSketchInput` from the host executor.
+    let input = sketch.finalize().await?;
+
+    // Feed the sketch into the client.
+    let input_bytes = bincode::serialize(&input)?;
+    let mut stdin = SP1Stdin::new();
+    stdin.write(&input_bytes);
+
+    let client = ProverClient::from_env();
+
+    // Execute the program using the `ProverClient.execute` method, without generating a proof.
+    let (_, report) = client.execute(ELF, &stdin).run().unwrap();
+    println!("executed program with {} cycles", report.total_instruction_count());
+
+    // Generate the proof for the given program and input.
+    let (pk, _) = client.setup(ELF);
+    let proof = client.prove(&pk, &stdin).run().unwrap();
+    println!("generated proof");
+
+    // Read the public values, and deserialize them.
+    let public_vals = ContractPublicValues::abi_decode(proof.public_values.as_slice())?;
+
+    // Print the fetched rates.
+    let gas_price = IGasPriceOracle::gasPriceCall::abi_decode_returns(&public_vals.contractOutput)?;
+    println!("Gas price: \n{:?}", gas_price);
+
+    Ok(())
+}

--- a/examples/optimism/host/src/main.rs
+++ b/examples/optimism/host/src/main.rs
@@ -1,17 +1,16 @@
 use alloy::sol;
 use alloy_primitives::{address, Address};
-use alloy_rpc_types::BlockNumberOrTag;
 use alloy_sol_types::{SolCall, SolType};
 use sp1_cc_client_executor::ContractPublicValues;
 use sp1_cc_host_executor::EvmSketch;
 use sp1_sdk::{include_elf, utils, ProverClient, SP1Stdin};
 use url::Url;
 
-const CONTRACT: Address = address!("0x420000000000000000000000000000000000000F");
+const CONTRACT: Address = address!("0x4200000000000000000000000000000000000015");
 
 sol! {
-    interface IGasPriceOracle {
-        function gasPrice() external view returns (uint256);
+    interface IL1Block {
+        function basefee() external view returns (uint256);
     }
 }
 
@@ -30,14 +29,10 @@ async fn main() -> eyre::Result<()> {
     // Use `OPTIMISM_RPC_URL` to get all of the necessary state for the smart contract call.
     let rpc_url = std::env::var("OPTIMISM_RPC_URL")
         .unwrap_or_else(|_| panic!("Missing OPTIMISM_RPC_URL in env"));
-    let sketch = EvmSketch::builder()
-        .optimism_mainnet()
-        .at_block(BlockNumberOrTag::Safe)
-        .el_rpc_url(Url::parse(&rpc_url)?)
-        .build()
-        .await?;
+    let sketch =
+        EvmSketch::builder().optimism_mainnet().el_rpc_url(Url::parse(&rpc_url)?).build().await?;
 
-    sketch.call(CONTRACT, Address::default(), IGasPriceOracle::gasPriceCall).await?;
+    sketch.call(CONTRACT, Address::default(), IL1Block::basefeeCall).await?;
 
     // Now that we've executed all of the calls, get the `EvmSketchInput` from the host executor.
     let input = sketch.finalize().await?;
@@ -62,8 +57,8 @@ async fn main() -> eyre::Result<()> {
     let public_vals = ContractPublicValues::abi_decode(proof.public_values.as_slice())?;
 
     // Print the fetched rates.
-    let gas_price = IGasPriceOracle::gasPriceCall::abi_decode_returns(&public_vals.contractOutput)?;
-    println!("Gas price: \n{:?}", gas_price);
+    let base_fee = IL1Block::basefeeCall::abi_decode_returns(&public_vals.contractOutput)?;
+    println!("Base fee: \n{:?}", base_fee);
 
     Ok(())
 }

--- a/examples/uniswap/client/src/main.rs
+++ b/examples/uniswap/client/src/main.rs
@@ -31,7 +31,7 @@ pub fn main() {
 
     // Initialize the client executor with the state sketch.
     // This step also validates all of the storage against the provided state root.
-    let executor = ClientExecutor::new(&state_sketch).unwrap();
+    let executor = ClientExecutor::eth(&state_sketch).unwrap();
 
     // Execute the slot0 call using the client executor.
     let slot0_call = IUniswapV3PoolState::slot0Call {};

--- a/examples/verify-quorum/client/src/main.rs
+++ b/examples/verify-quorum/client/src/main.rs
@@ -30,7 +30,7 @@ pub fn main() {
 
     // Initialize the client executor with the state sketch.
     // This step also validates all of the storage against the provided state root.
-    let executor = ClientExecutor::new(&state_sketch).unwrap();
+    let executor = ClientExecutor::eth(&state_sketch).unwrap();
 
     // Set up the call to `verifySigned`.
     let verify_signed_call = ContractInput::new_call(


### PR DESCRIPTION
In this PR:

* Added a `optimism` feature in the host and client to allow to execute calls the `OpEvm` on OP stack chains.
* On the host, added `optimism()` fn on `EvmSketchBuilder`.
* On the client side, the `ClientExecutor` should be created with `optimism()` fn. I've set `new()` private to avoid mistakes.