### PR TITLE
chore: bump RSP version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6639,7 +6639,7 @@ dependencies = [
 [[package]]
 name = "rsp-client-executor"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.8.2#e39d5fea281ed5e22dd5d572e02b650699af97ec"
+source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.8.2b#805ca49639c23b0ed345db9b1fa50349cb3c92b6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -6671,7 +6671,7 @@ dependencies = [
 [[package]]
 name = "rsp-mpt"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.8.2#e39d5fea281ed5e22dd5d572e02b650699af97ec"
+source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.8.2b#805ca49639c23b0ed345db9b1fa50349cb3c92b6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "rsp-primitives"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.8.2#e39d5fea281ed5e22dd5d572e02b650699af97ec"
+source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.8.2b#805ca49639c23b0ed345db9b1fa50349cb3c92b6"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -6707,7 +6707,7 @@ dependencies = [
 [[package]]
 name = "rsp-rpc-db"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.8.2#e39d5fea281ed5e22dd5d572e02b650699af97ec"
+source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.8.2b#805ca49639c23b0ed345db9b1fa50349cb3c92b6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6731,7 +6731,7 @@ dependencies = [
 [[package]]
 name = "rsp-witness-db"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.8.2#e39d5fea281ed5e22dd5d572e02b650699af97ec"
+source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.8.2b#805ca49639c23b0ed345db9b1fa50349cb3c92b6"
 dependencies = [
  "alloy-primitives",
  "reth-storage-errors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,11 +50,11 @@ sp1-zkvm = "5.2.1"
 sp1-build = "5.2.1"
 
 # rsp
-rsp-rpc-db = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.8.2" }
-rsp-witness-db = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.8.2" }
-rsp-primitives = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.8.2" }
-rsp-client-executor = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.8.2" }
-rsp-mpt = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.8.2" }
+rsp-rpc-db = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.8.2b" }
+rsp-witness-db = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.8.2b" }
+rsp-primitives = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.8.2b" }
+rsp-client-executor = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.8.2b" }
+rsp-mpt = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.8.2b" }
 
 # rsp-rpc-db = { path = "../rsp/crates/storage/rpc-db" }
 # rsp-witness-db = { path = "../rsp/crates/storage/witness-db" }


### PR DESCRIPTION
Bump RSP version in order to fix an issue with Sepolia where the blob params were incorrectly set