### PR TITLE
chore: bump rsp to reth-1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6712,7 +6712,7 @@ dependencies = [
 [[package]]
 name = "rsp-client-executor"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.0-rc.1#fcb865684eb28ea0d24fb9fa47714a41dbba3ac1"
+source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.0#2c5718029e7c0b24a34b011088fef221489fc714"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -6745,7 +6745,7 @@ dependencies = [
 [[package]]
 name = "rsp-mpt"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.0-rc.1#fcb865684eb28ea0d24fb9fa47714a41dbba3ac1"
+source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.0#2c5718029e7c0b24a34b011088fef221489fc714"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6760,13 +6760,11 @@ dependencies = [
 [[package]]
 name = "rsp-primitives"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.0-rc.1#fcb865684eb28ea0d24fb9fa47714a41dbba3ac1"
+source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.0#2c5718029e7c0b24a34b011088fef221489fc714"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives",
  "alloy-rpc-types",
- "alloy-serde",
  "reth-chainspec",
  "reth-optimism-chainspec",
  "reth-optimism-forks",
@@ -6781,7 +6779,7 @@ dependencies = [
 [[package]]
 name = "rsp-rpc-db"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.0-rc.1#fcb865684eb28ea0d24fb9fa47714a41dbba3ac1"
+source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.0#2c5718029e7c0b24a34b011088fef221489fc714"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6805,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "rsp-witness-db"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.0-rc.1#fcb865684eb28ea0d24fb9fa47714a41dbba3ac1"
+source = "git+https://github.com/succinctlabs/rsp?tag=reth-1.9.0#2c5718029e7c0b24a34b011088fef221489fc714"
 dependencies = [
  "alloy-primitives",
  "reth-storage-errors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,11 +50,11 @@ sp1-zkvm = "5.2.1"
 sp1-build = "5.2.1"
 
 # rsp
-rsp-rpc-db = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.9.0-rc.1" }
-rsp-witness-db = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.9.0-rc.1" }
-rsp-primitives = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.9.0-rc.1" }
-rsp-client-executor = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.9.0-rc.1" }
-rsp-mpt = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.9.0-rc.1" }
+rsp-rpc-db = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.9.0" }
+rsp-witness-db = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.9.0" }
+rsp-primitives = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.9.0" }
+rsp-client-executor = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.9.0" }
+rsp-mpt = { git = "https://github.com/succinctlabs/rsp", tag = "reth-1.9.0" }
 
 # rsp-rpc-db = { path = "../rsp/crates/storage/rpc-db" }
 # rsp-witness-db = { path = "../rsp/crates/storage/witness-db" }


### PR DESCRIPTION
TODO: bump rsp to reth-1.9.0 once [this PR](https://github.com/succinctlabs/rsp/pull/162) is merged and we have an official release. 