### PR TITLE
feat: add EvmSketchBuilder::el_rpc_client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7639,6 +7639,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-provider",
+ "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-sol-macro",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ alloy-node-bindings = { version = "1.0.37", default-features = false }
 alloy-provider = { version = "1.0.37", default-features = false, features = [
     "reqwest",
 ] }
+alloy-rpc-client = { version = "1.0.37", default-features = false }
 alloy-rpc-types = { version = "1.0.37", default-features = false, features = [
     "eth",
 ] }

--- a/crates/host-executor/Cargo.toml
+++ b/crates/host-executor/Cargo.toml
@@ -42,9 +42,10 @@ alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-provider.workspace = true
-alloy-transport.workspace = true
+alloy-rpc-client.workspace = true
 alloy-sol-macro.workspace = true
 alloy-sol-types.workspace = true
+alloy-transport.workspace = true
 alloy-rpc-types.workspace = true
 alloy-evm.workspace = true
 

--- a/crates/host-executor/src/sketch_builder.rs
+++ b/crates/host-executor/src/sketch_builder.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use alloy_eips::BlockId;
 use alloy_provider::{network::AnyNetwork, Provider, RootProvider};
+use alloy_rpc_client::RpcClient;
 use reth_primitives::EthPrimitives;
 use rsp_primitives::genesis::Genesis;
 use rsp_rpc_db::BasicRpcDb;
@@ -46,6 +47,21 @@ impl<PT> EvmSketchBuilder<(), PT, ()> {
     ) -> EvmSketchBuilder<RootProvider<AnyNetwork>, PT, HeaderAnchorBuilder<RootProvider<AnyNetwork>>>
     {
         let provider = RootProvider::new_http(rpc_url);
+        EvmSketchBuilder {
+            block: self.block,
+            genesis: self.genesis,
+            provider: provider.clone(),
+            anchor_builder: HeaderAnchorBuilder::new(provider),
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn el_rpc_client(
+        self,
+        rpc_client: RpcClient,
+    ) -> EvmSketchBuilder<RootProvider<AnyNetwork>, PT, HeaderAnchorBuilder<RootProvider<AnyNetwork>>>
+    {
+        let provider = RootProvider::new(rpc_client);
         EvmSketchBuilder {
             block: self.block,
             genesis: self.genesis,


### PR DESCRIPTION
The current method `pub fn el_rpc_url(self, rpc_url: Url) -> EvmSketchBuilder` is too restrictive because it only accepts a raw `Url`. I need the ability to provide a custom `RpcClient` that supports additional functionality such as auto-retry and throttling.

This PR introduces a more flexible alternative: `pub fn el_rpc_client(self, rpc_client: RpcClient) -> EvmSketchBuilder`.

With this change, instead of supplying a simple `rpc_url: Url`, I can now pass a fully customized `rpc_client: RpcClient` with enhanced capabilities.
